### PR TITLE
Set SELinux labels for mounted scripts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,8 @@ IMAGE_NAME := jamesantill/boltron-27
 SYSTEMD_CONTAINER_NAME := boltron
 DOCKER_FNAME := Dockerfile
 # DOCKER_FNAME := Dockerfile-with-local-dnf
+# Remove this if you don't have SELinux mounting patches, *sigh* ...
+SELINUX := :z
 
 help:
 		@echo "make build - Build a new docker image."
@@ -46,9 +48,9 @@ tests-hdr: tests-setup
 		@echo "==============================================================="
 		@echo "Getting test data for $(TESTD)"
 		@docker run --rm test-$(IMAGE_NAME) /image-data all > $(TESTD)/hdr
-		@docker run --rm -v $$(pwd):/mnt:z  test-$(IMAGE_NAME) /mnt/list-modules-py3.py > $(TESTD)/mods
-		@docker run --rm -v $$(pwd):/mnt:z  test-$(IMAGE_NAME) /mnt/list-rpm.sh > $(TESTD)/rpm
-		@docker run --rm -v $$(pwd):/mnt:z  test-$(IMAGE_NAME) /mnt/list-repos-py3.py > $(TESTD)/repos
+		@docker run --rm -v $$(pwd):/mnt$(SELINUX)  test-$(IMAGE_NAME) /mnt/list-modules-py3.py > $(TESTD)/mods
+		@docker run --rm -v $$(pwd):/mnt$(SELINUX)  test-$(IMAGE_NAME) /mnt/list-rpm.sh > $(TESTD)/rpm
+		@docker run --rm -v $$(pwd):/mnt$(SELINUX)  test-$(IMAGE_NAME) /mnt/list-repos-py3.py > $(TESTD)/repos
 		@echo "---------------------------------------------------------------"
 
 tests: tests-hdr

--- a/Makefile
+++ b/Makefile
@@ -46,9 +46,9 @@ tests-hdr: tests-setup
 		@echo "==============================================================="
 		@echo "Getting test data for $(TESTD)"
 		@docker run --rm test-$(IMAGE_NAME) /image-data all > $(TESTD)/hdr
-		@docker run --rm -v $$(pwd):/mnt  test-$(IMAGE_NAME) /mnt/list-modules-py3.py > $(TESTD)/mods
-		@docker run --rm -v $$(pwd):/mnt  test-$(IMAGE_NAME) /mnt/list-rpm.sh > $(TESTD)/rpm
-		@docker run --rm -v $$(pwd):/mnt  test-$(IMAGE_NAME) /mnt/list-repos-py3.py > $(TESTD)/repos
+		@docker run --rm -v $$(pwd):/mnt:z  test-$(IMAGE_NAME) /mnt/list-modules-py3.py > $(TESTD)/mods
+		@docker run --rm -v $$(pwd):/mnt:z  test-$(IMAGE_NAME) /mnt/list-rpm.sh > $(TESTD)/rpm
+		@docker run --rm -v $$(pwd):/mnt:z  test-$(IMAGE_NAME) /mnt/list-repos-py3.py > $(TESTD)/repos
 		@echo "---------------------------------------------------------------"
 
 tests: tests-hdr


### PR DESCRIPTION
Without auto-adjusting the SELinux labels,
I get a permissions error when attempting
to run the tests on F26 as a regular user.