### PR TITLE
Remove mc (Midnight Commander)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,7 +37,6 @@ tar \
 bzip2 \
 xz \
 which \
-mc \
 less \
  && dnf clean all
 RUN echo "enabled=false" >> /etc/yum.repos.d/fedora.repo


### PR DESCRIPTION
mc depends on both Perl and Python 2.7, so including
it causes problems when checking the behaviour of
those modules.

Fixes #4 