### PR TITLE
Link results for latest completed F27 image build

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,9 +39,6 @@ You should now be able to build the image locally:
 
     $ make build
 
-(Later rebuilds may require a `make upbase && make update` to pick up newer
-pre-release images from Fedora)
-
 The basic image tests, which run through and check that each currently
 defined module can be installed, can be run via:
 

--- a/README.md
+++ b/README.md
@@ -39,10 +39,13 @@ You should now be able to build the image locally:
 
     $ make build
 
+(Later rebuilds may require a `make upbase && make update` to pick up newer
+pre-release images from Fedora)
+
 The basic image tests, which run through and check that each currently
 defined module can be installed, can be run via:
 
-   $ make tests
+    $ make tests
 
 Checking specific F27 modules
 -----------------------------
@@ -52,7 +55,8 @@ pre-release testing platform for the individual modules included in the F27
 Modular Server release.
 
 The most recent test logs for the actual F27 Modular Server builds can be
-found [here](https://ci.centos.org/job/fedora-qa-compose_tester/lastSuccessfulBuild/artifact/compose_tester/mod_install_results.log).
+found [here](https://ci.centos.org/job/fedora-qa-compose_tester/lastCompletedBuild/artifact/compose_tester/mod_install_results.log), with the error details
+[here](https://ci.centos.org/job/fedora-qa-compose-tests/lastCompletedBuild/artifact/compose-tests/error.log).
 
 Before checking the behaviour of a module in the image, confirm that it has
 been built successfully by going to


### PR DESCRIPTION
The F27 image builds are failing their tests, so we want
to link to the last completed build, not the last successful
one.