### PR TITLE
Automatically build mbs-cli binary

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,10 @@ tag:
 		@docker tag $(IMAGE_NAME) $(IMAGE_NAME):$$(cat latest-Fedora-Modular-27.COMPOSE_ID)
 upbase:
 		@./up-base.sh
-build:
+build-mbs-cli:
+		@go get gopkg.in/yaml.v2
+		@go build mbs-cli.go
+build: build-mbs-cli
 		@docker build --file=$(DOCKER_FNAME) . -t $(IMAGE_NAME)
 		@docker tag $(IMAGE_NAME) $(IMAGE_NAME):$$(cat latest-Fedora-Modular-27.COMPOSE_ID)
 build-force:

--- a/Makefile
+++ b/Makefile
@@ -20,10 +20,10 @@ tag:
 		@docker tag $(IMAGE_NAME) $(IMAGE_NAME):$$(cat latest-Fedora-Modular-27.COMPOSE_ID)
 upbase:
 		@./up-base.sh
-build-mbs-cli:
+mbs-cli:
 		@go get gopkg.in/yaml.v2
 		@go build mbs-cli.go
-build: build-mbs-cli
+build: mbs-cli
 		@docker build --file=$(DOCKER_FNAME) . -t $(IMAGE_NAME)
 		@docker tag $(IMAGE_NAME) $(IMAGE_NAME):$$(cat latest-Fedora-Modular-27.COMPOSE_ID)
 build-force:


### PR DESCRIPTION
Without this, attempting to build the
image in a fresh or updated clone fails
when the `mbs-cli` binary hasn't been built

Fixes #10 